### PR TITLE
🐛 fix "unslick" setting for removing slider

### DIFF
--- a/demo/pages/examples/configs.js
+++ b/demo/pages/examples/configs.js
@@ -83,6 +83,10 @@ export default {
             slidesToScroll: 1,
           },
         },
+        {
+          breakpoint: 320,
+          settings: 'unslick',
+        },
       ],
     },
   },

--- a/src/VueSlickCarousel.vue
+++ b/src/VueSlickCarousel.vue
@@ -177,11 +177,15 @@ export default {
   },
   render() {
     const { settings } = this
+    let children = this.$slots.default || []
+    if (settings === 'unslick') {
+      return <div class="regular slider">{children}</div>
+    }
     settings.prevArrow = this.$scopedSlots.prevArrow
     settings.nextArrow = this.$scopedSlots.nextArrow
     settings.customPaging = this.$scopedSlots.customPaging
-    let children = this.$slots.default || []
     children = children.filter(child => !!child.tag)
+
     let newChildren = []
     let currentWidth = null
     for (
@@ -223,9 +227,7 @@ export default {
       }
     }
 
-    if (settings === 'unslick') {
-      return <div class="regular slider">{newChildren}</div>
-    } else if (newChildren.length <= settings.slidesToShow) {
+    if (newChildren.length <= settings.slidesToShow) {
       settings.unslick = true
     }
 


### PR DESCRIPTION
Replace check for settings==='unslick' before assuming that settings is an object, returning just div without slider functionality. 

@kyuwoo-choi, please revise these changes and let me know if anything needs to be adjusted. 