### PR TITLE
Handle unslick value after "fetch" in nuxtjs

### DIFF
--- a/src/VueSlickCarousel.vue
+++ b/src/VueSlickCarousel.vue
@@ -227,9 +227,7 @@ export default {
       }
     }
 
-    if (newChildren.length <= settings.slidesToShow) {
-      settings.unslick = true
-    }
+    settings.unslick = newChildren.length <= settings.slidesToShow
 
     return (
       <InnerSlider


### PR DESCRIPTION
If the children of the `VueSlickCarousel` change during the app to a number less than `slidesToShow` i.e. (`newChildren.length <= settings.slidesToShow`), the `settings.unslick` will change to true. But, after that, if the number increase, `unslick` will not disable at all.