### PR TITLE
Handle the plugin if the "length" of the children is 0

### DIFF
--- a/src/InnerSlider.vue
+++ b/src/InnerSlider.vue
@@ -53,7 +53,7 @@ export default {
   },
   computed: {
     slideCount() {
-      return this.$slots.default.length
+      return (this.$slots.default && this.$slots.default.length) || 0
     },
     spec() {
       return {

--- a/src/InnerSlider.vue
+++ b/src/InnerSlider.vue
@@ -166,7 +166,7 @@ export default {
       }
       let setTrackStyle = false
       for (let key of Object.keys(this.$props)) {
-        if (!nextProps.hasOwnProperty.call(nextProps, key)) {
+        if (!nextProps.hasOwnProperty(key)) {
           setTrackStyle = true
           break
         }
@@ -217,7 +217,6 @@ export default {
     ssrInit() {
       const preClones = getPreClones(this.spec)
       const postClones = getPostClones(this.spec)
-      // console.log(this.currentSlide, this.slideCount, preClones, postClones)
       if (this.variableWidth) {
         let trackWidth = [],
           trackLeft = []
@@ -501,10 +500,14 @@ export default {
     },
     play() {
       var nextIndex
-      if (canGoNext({ ...this.$props, ...this.$data })) {
-        nextIndex = this.currentSlide + this.slidesToScroll
+      if (this.rtl) {
+        nextIndex = this.currentSlide - this.slidesToScroll
       } else {
-        return false
+        if (canGoNext({ ...this.$props, ...this.$data })) {
+          nextIndex = this.currentSlide + this.slidesToScroll
+        } else {
+          return false
+        }
       }
 
       this.slideHandler(nextIndex)
@@ -677,8 +680,7 @@ export default {
     })
 
     return (
-      // <div class={className} dir={!this.unslick ? 'ltr' : false}>
-      <div class={className} dir={!this.rtl ? 'ltr' : 'rtl'}>
+      <div class={className} dir={!this.unslick ? 'ltr' : false}>
         {!this.unslick ? prevArrow : ''}
         <div
           ref="list"

--- a/src/InnerSlider.vue
+++ b/src/InnerSlider.vue
@@ -166,7 +166,7 @@ export default {
       }
       let setTrackStyle = false
       for (let key of Object.keys(this.$props)) {
-        if (!nextProps.hasOwnProperty(key)) {
+        if (!nextProps.hasOwnProperty.call(nextProps, key)) {
           setTrackStyle = true
           break
         }
@@ -217,6 +217,7 @@ export default {
     ssrInit() {
       const preClones = getPreClones(this.spec)
       const postClones = getPostClones(this.spec)
+      // console.log(this.currentSlide, this.slideCount, preClones, postClones)
       if (this.variableWidth) {
         let trackWidth = [],
           trackLeft = []
@@ -500,14 +501,10 @@ export default {
     },
     play() {
       var nextIndex
-      if (this.rtl) {
-        nextIndex = this.currentSlide - this.slidesToScroll
+      if (canGoNext({ ...this.$props, ...this.$data })) {
+        nextIndex = this.currentSlide + this.slidesToScroll
       } else {
-        if (canGoNext({ ...this.$props, ...this.$data })) {
-          nextIndex = this.currentSlide + this.slidesToScroll
-        } else {
-          return false
-        }
+        return false
       }
 
       this.slideHandler(nextIndex)
@@ -680,7 +677,8 @@ export default {
     })
 
     return (
-      <div class={className} dir={!this.unslick ? 'ltr' : false}>
+      // <div class={className} dir={!this.unslick ? 'ltr' : false}>
+      <div class={className} dir={!this.rtl ? 'ltr' : 'rtl'}>
         {!this.unslick ? prevArrow : ''}
         <div
           ref="list"

--- a/src/SliderTrack.vue
+++ b/src/SliderTrack.vue
@@ -124,14 +124,8 @@ export default {
           } else {
             child = <div />
           }
-          let childStyle = getSlideStyle({
-            ...spec,
-            index,
-          })
-          let slideClasses = getSlideClasses({
-            ...spec,
-            index,
-          })
+          let childStyle = getSlideStyle({ ...spec, index })
+          let slideClasses = getSlideClasses({ ...spec, index })
           // push a cloned element of the desired slide
           slides.push(
             this.cloneSlide(child, {
@@ -165,10 +159,7 @@ export default {
               if (key >= startIndex) {
                 child = elem
               }
-              slideClasses = getSlideClasses({
-                ...spec,
-                index: key,
-              })
+              slideClasses = getSlideClasses({ ...spec, index: key })
               preCloneSlides.push(
                 this.cloneSlide(child, {
                   key: 'precloned' + getKey(child, key),
@@ -189,10 +180,7 @@ export default {
               if (key < endIndex) {
                 child = elem
               }
-              slideClasses = getSlideClasses({
-                ...spec,
-                index: key,
-              })
+              slideClasses = getSlideClasses({ ...spec, index: key })
               postCloneSlides.push(
                 this.cloneSlide(child, {
                   key: 'postcloned' + getKey(child, key),
@@ -221,7 +209,7 @@ export default {
     const slides = this.renderSlides(this.$props, this.$slots.default)
     return (
       <div
-        class={{ 'slick-track': true, 'slick-center': this.centerMode }}
+        class={{ 'slick-track': true, 'slick-center': this.$props.centerMode }}
         style={this.trackStyle}>
         {slides}
       </div>

--- a/src/SliderTrack.vue
+++ b/src/SliderTrack.vue
@@ -101,7 +101,7 @@ export default {
       let slides = []
       let preCloneSlides = []
       let postCloneSlides = []
-      let childrenCount = children.length
+      let childrenCount = (children && children.length) || 0
       let startIndex = lazyStartIndex(spec)
       let endIndex = lazyEndIndex(spec)
 

--- a/src/SliderTrack.vue
+++ b/src/SliderTrack.vue
@@ -124,8 +124,14 @@ export default {
           } else {
             child = <div />
           }
-          let childStyle = getSlideStyle({ ...spec, index })
-          let slideClasses = getSlideClasses({ ...spec, index })
+          let childStyle = getSlideStyle({
+            ...spec,
+            index,
+          })
+          let slideClasses = getSlideClasses({
+            ...spec,
+            index,
+          })
           // push a cloned element of the desired slide
           slides.push(
             this.cloneSlide(child, {
@@ -159,7 +165,10 @@ export default {
               if (key >= startIndex) {
                 child = elem
               }
-              slideClasses = getSlideClasses({ ...spec, index: key })
+              slideClasses = getSlideClasses({
+                ...spec,
+                index: key,
+              })
               preCloneSlides.push(
                 this.cloneSlide(child, {
                   key: 'precloned' + getKey(child, key),
@@ -180,7 +189,10 @@ export default {
               if (key < endIndex) {
                 child = elem
               }
-              slideClasses = getSlideClasses({ ...spec, index: key })
+              slideClasses = getSlideClasses({
+                ...spec,
+                index: key,
+              })
               postCloneSlides.push(
                 this.cloneSlide(child, {
                   key: 'postcloned' + getKey(child, key),
@@ -209,7 +221,7 @@ export default {
     const slides = this.renderSlides(this.$props, this.$slots.default)
     return (
       <div
-        class={{ 'slick-track': true, 'slick-center': this.$props.centerMode }}
+        class={{ 'slick-track': true, 'slick-center': this.centerMode }}
         style={this.trackStyle}>
         {slides}
       </div>

--- a/src/SliderTrack.vue
+++ b/src/SliderTrack.vue
@@ -105,97 +105,98 @@ export default {
       let startIndex = lazyStartIndex(spec)
       let endIndex = lazyEndIndex(spec)
 
-      children.forEach((elem, index) => {
-        let child
-        let childOnClickOptions = {
-          message: 'children',
-          index: index,
-          slidesToScroll: spec.slidesToScroll,
-          currentSlide: spec.currentSlide,
-        }
+      children &&
+        children.forEach((elem, index) => {
+          let child
+          let childOnClickOptions = {
+            message: 'children',
+            index: index,
+            slidesToScroll: spec.slidesToScroll,
+            currentSlide: spec.currentSlide,
+          }
 
-        // in case of lazyLoad, whether or not we want to fetch the slide
-        if (
-          !spec.lazyLoad ||
-          (spec.lazyLoad && spec.lazyLoadedList.indexOf(index) >= 0)
-        ) {
-          child = elem
-        } else {
-          child = <div />
-        }
-        let childStyle = getSlideStyle({ ...spec, index })
-        let slideClasses = getSlideClasses({ ...spec, index })
-        // push a cloned element of the desired slide
-        slides.push(
-          this.cloneSlide(child, {
-            key: 'original' + getKey(child, index),
-            class: slideClasses,
-            style: {
-              outline: 'none',
-              ...childStyle,
-            },
-            attrs: {
-              tabIndex: '-1',
-              'data-index': index,
-              'aria-hidden': `${!slideClasses['slick-active']}`,
-            },
-            childOnClickOptions,
-          }),
-        )
-
-        // if slide needs to be precloned or postcloned
-        if (
-          spec.infinite &&
-          spec.fade === false &&
-          childrenCount > spec.slidesToShow
-        ) {
-          let preCloneNo = childrenCount - index
+          // in case of lazyLoad, whether or not we want to fetch the slide
           if (
-            preCloneNo <= getPreClones(spec) &&
-            childrenCount !== spec.slidesToShow
+            !spec.lazyLoad ||
+            (spec.lazyLoad && spec.lazyLoadedList.indexOf(index) >= 0)
           ) {
-            key = -preCloneNo
-            if (key >= startIndex) {
-              child = elem
-            }
-            slideClasses = getSlideClasses({ ...spec, index: key })
-            preCloneSlides.push(
-              this.cloneSlide(child, {
-                key: 'precloned' + getKey(child, key),
-                class: slideClasses,
-                style: childStyle,
-                attrs: {
-                  tabIndex: '-1',
-                  'data-index': key,
-                  'aria-hidden': `${!slideClasses['slick-active']}`,
-                },
-                childOnClickOptions,
-              }),
-            )
+            child = elem
+          } else {
+            child = <div />
           }
+          let childStyle = getSlideStyle({ ...spec, index })
+          let slideClasses = getSlideClasses({ ...spec, index })
+          // push a cloned element of the desired slide
+          slides.push(
+            this.cloneSlide(child, {
+              key: 'original' + getKey(child, index),
+              class: slideClasses,
+              style: {
+                outline: 'none',
+                ...childStyle,
+              },
+              attrs: {
+                tabIndex: '-1',
+                'data-index': index,
+                'aria-hidden': `${!slideClasses['slick-active']}`,
+              },
+              childOnClickOptions,
+            }),
+          )
 
-          if (childrenCount !== spec.slidesToShow) {
-            key = childrenCount + index
-            if (key < endIndex) {
-              child = elem
+          // if slide needs to be precloned or postcloned
+          if (
+            spec.infinite &&
+            spec.fade === false &&
+            childrenCount > spec.slidesToShow
+          ) {
+            let preCloneNo = childrenCount - index
+            if (
+              preCloneNo <= getPreClones(spec) &&
+              childrenCount !== spec.slidesToShow
+            ) {
+              key = -preCloneNo
+              if (key >= startIndex) {
+                child = elem
+              }
+              slideClasses = getSlideClasses({ ...spec, index: key })
+              preCloneSlides.push(
+                this.cloneSlide(child, {
+                  key: 'precloned' + getKey(child, key),
+                  class: slideClasses,
+                  style: childStyle,
+                  attrs: {
+                    tabIndex: '-1',
+                    'data-index': key,
+                    'aria-hidden': `${!slideClasses['slick-active']}`,
+                  },
+                  childOnClickOptions,
+                }),
+              )
             }
-            slideClasses = getSlideClasses({ ...spec, index: key })
-            postCloneSlides.push(
-              this.cloneSlide(child, {
-                key: 'postcloned' + getKey(child, key),
-                class: slideClasses,
-                style: childStyle,
-                attrs: {
-                  tabIndex: '-1',
-                  'data-index': key,
-                  'aria-hidden': `${!slideClasses['slick-active']}`,
-                },
-                childOnClickOptions,
-              }),
-            )
+
+            if (childrenCount !== spec.slidesToShow) {
+              key = childrenCount + index
+              if (key < endIndex) {
+                child = elem
+              }
+              slideClasses = getSlideClasses({ ...spec, index: key })
+              postCloneSlides.push(
+                this.cloneSlide(child, {
+                  key: 'postcloned' + getKey(child, key),
+                  class: slideClasses,
+                  style: childStyle,
+                  attrs: {
+                    tabIndex: '-1',
+                    'data-index': key,
+                    'aria-hidden': `${!slideClasses['slick-active']}`,
+                  },
+                  childOnClickOptions,
+                }),
+              )
+            }
           }
-        }
-      }, this)
+        }, this)
 
       if (spec.rtl) {
         return preCloneSlides.concat(slides, postCloneSlides).reverse()

--- a/src/VueSlickCarousel.vue
+++ b/src/VueSlickCarousel.vue
@@ -227,9 +227,7 @@ export default {
       }
     }
 
-    if (newChildren.length <= settings.slidesToShow) {
-      settings.unslick = true
-    }
+    settings.unslick = newChildren.length <= settings.slidesToShow
 
     return (
       <InnerSlider

--- a/src/innerSliderUtils.js
+++ b/src/innerSliderUtils.js
@@ -622,7 +622,7 @@ export const getSwipeDirection = (touchObject, verticalSwiping = false) => {
 // get initialized state
 export const initializedState = spec => {
   // spec also contains listRef, trackRef
-  let slideCount = spec.children.length
+  let slideCount = (spec.children && spec.children.length) || 0
   let listWidth = Math.ceil(getWidth(spec.listRef))
   let trackWidth = Math.ceil(getWidth(spec.trackRef))
   let slideWidth

--- a/src/innerSliderUtils.js
+++ b/src/innerSliderUtils.js
@@ -240,7 +240,7 @@ export const swipeMove = (e, spec) => {
     positionOffset = touchObject.curY > touchObject.startY ? 1 : -1
 
   let dotCount = Math.ceil(slideCount / slidesToScroll)
-  let swipeDirection = getSwipeDirection(spec.touchObject, verticalSwiping, rtl)
+  let swipeDirection = getSwipeDirection(spec.touchObject, verticalSwiping)
   let touchSwipeLength = touchObject.swipeLength
   if (!infinite) {
     if (
@@ -260,7 +260,11 @@ export const swipeMove = (e, spec) => {
     state['swiped'] = true
   }
   if (!vertical) {
-    swipeLeft = curLeft + touchSwipeLength * positionOffset
+    if (!rtl) {
+      swipeLeft = curLeft + touchSwipeLength * positionOffset
+    } else {
+      swipeLeft = curLeft - touchSwipeLength * positionOffset
+    }
   } else {
     swipeLeft =
       curLeft + touchSwipeLength * (listHeight / listWidth) * positionOffset
@@ -299,7 +303,6 @@ export const swipeEnd = (e, spec) => {
     swipeToSlide,
     scrolling,
     onSwipe,
-    rtl,
   } = spec
   if (!dragging) {
     if (swipe) e.preventDefault()
@@ -308,7 +311,7 @@ export const swipeEnd = (e, spec) => {
   let minSwipe = verticalSwiping
     ? listHeight / touchThreshold
     : listWidth / touchThreshold
-  let swipeDirection = getSwipeDirection(touchObject, verticalSwiping, rtl)
+  let swipeDirection = getSwipeDirection(touchObject, verticalSwiping)
   // reset the state of touch related state variables.
   let state = {
     dragging: false,
@@ -587,11 +590,7 @@ export const slideHandler = spec => {
 export const getWidth = elem => (elem && elem.offsetWidth) || 0
 export const getHeight = elem => (elem && elem.offsetHeight) || 0
 
-export const getSwipeDirection = (
-  touchObject,
-  verticalSwiping = false,
-  rtl = false,
-) => {
+export const getSwipeDirection = (touchObject, verticalSwiping = false) => {
   var xDist, yDist, r, swipeAngle
   xDist = touchObject.startX - touchObject.curX
   yDist = touchObject.startY - touchObject.curY
@@ -604,10 +603,10 @@ export const getSwipeDirection = (
     (swipeAngle <= 45 && swipeAngle >= 0) ||
     (swipeAngle <= 360 && swipeAngle >= 315)
   ) {
-    return !rtl ? 'left' : 'right'
+    return 'left'
   }
   if (swipeAngle >= 135 && swipeAngle <= 225) {
-    return !rtl ? 'right' : 'left'
+    return 'right'
   }
   if (verticalSwiping === true) {
     if (swipeAngle >= 35 && swipeAngle <= 135) {
@@ -644,6 +643,9 @@ export const initializedState = spec => {
   let listHeight = slideHeight * spec.slidesToShow
   let currentSlide =
     spec.currentSlide === undefined ? spec.initialSlide : spec.currentSlide
+  if (spec.rtl && spec.currentSlide === undefined) {
+    currentSlide = slideCount - 1 - spec.initialSlide
+  }
   let lazyLoadedList = spec.lazyLoadedList || []
   let slidesToLoad = getOnDemandLazySlides(
     { currentSlide, lazyLoadedList },
@@ -779,10 +781,7 @@ export const getTotalSlides = spec =>
     : getPreClones(spec) + spec.slideCount + getPostClones(spec)
 
 export const checkSpecKeys = (spec, keysArray) =>
-  keysArray.reduce(
-    (value, key) => value && spec.hasOwnProperty.call(spec, key),
-    true,
-  )
+  keysArray.reduce((value, key) => value && spec.hasOwnProperty(key), true)
     ? null
     : console.error('Keys Missing:', spec) // eslint-disable-line no-console
 
@@ -807,15 +806,14 @@ export const getTrackCSS = spec => {
     WebkitTransition: '',
   }
   if (spec.useTransform) {
-    const correctedLeft = spec.rtl ? -spec.left : spec.left
     let WebkitTransform = !spec.vertical
-      ? 'translate3d(' + correctedLeft + 'px, 0px, 0px)'
+      ? 'translate3d(' + spec.left + 'px, 0px, 0px)'
       : 'translate3d(0px, ' + spec.left + 'px, 0px)'
     let transform = !spec.vertical
-      ? 'translate3d(' + correctedLeft + 'px, 0px, 0px)'
+      ? 'translate3d(' + spec.left + 'px, 0px, 0px)'
       : 'translate3d(0px, ' + spec.left + 'px, 0px)'
     let msTransform = !spec.vertical
-      ? 'translateX(' + correctedLeft + 'px)'
+      ? 'translateX(' + spec.left + 'px)'
       : 'translateY(' + spec.left + 'px)'
     style = {
       ...style,


### PR DESCRIPTION
If the length of the children is zero, some of the variables will be `undefined`, in addition, getting the `length` of an `undefined` variable raises an exception. So, we must handle this to prevent the app from crashing. (#75 and #102)

It can happen if the user wants to `fetch` in Nuxt-js. At the first time, there is no child and it leads to crash the app.