### PR TITLE
Fix - Disabled autoplay still fires events `beforeChange`

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Unsure where to begin contributing? You can start by looking through these `docu
 ### Development WorkFlow
 
 - Set up your development environment
-- Be sure the code passes `yarn lint`, `yarn test`
+- Be sure the code passes `yarn lint`, `yarn test:unit`
 - Make a pull request
 
 ### Development Environment

--- a/src/InnerSlider.vue
+++ b/src/InnerSlider.vue
@@ -88,8 +88,8 @@ export default {
     }
     this.updateState(spec, true)
     this.adaptHeight()
-    if (this.autoPlay) {
-      this.autoPlay('update')
+    if (this.autoplay) {
+      this.runAutoPlay('update')
     }
     if (this.lazyLoad === 'progressive') {
       this.lazyLoadTimer = setInterval(this.progressiveLazyLoad, 1000)
@@ -190,7 +190,7 @@ export default {
         })
       }
       if (nextProps.autoplay) {
-        this.autoPlay('update')
+        this.runAutoPlay('update')
       } else {
         this.pause('paused')
       }
@@ -324,7 +324,7 @@ export default {
       }
       this.updateState(spec, setTrackStyle)
       if (this.autoplay) {
-        this.autoPlay('update')
+        this.runAutoPlay('update')
       } else {
         this.pause('paused')
       }
@@ -512,7 +512,7 @@ export default {
 
       this.slideHandler(nextIndex)
     },
-    autoPlay(playType) {
+    runAutoPlay(playType) {
       if (this.autoplayTimer) {
         clearInterval(this.autoplayTimer)
       }
@@ -557,22 +557,34 @@ export default {
       }
     },
     onDotsOver() {
-      this.autoplay && this.pause('hovered')
+      if (this.autoplay) {
+        this.pause('hovered')
+      }
     },
     onDotsLeave() {
-      this.autoplay && this.autoplaying === 'hovered' && this.autoPlay('leave')
+      if (this.autoplay && this.autoplaying === 'hovered') {
+        this.runAutoPlay('leave')
+      }
     },
     onTrackOver() {
-      this.autoplay && this.pause('hovered')
+      if (this.autoplay) {
+        this.pause('hovered')
+      }
     },
     onTrackLeave() {
-      this.autoplay && this.autoplaying === 'hovered' && this.autoPlay('leave')
+      if (this.autoplay && this.autoplaying === 'hovered') {
+        this.runAutoPlay('leave')
+      }
     },
     onSlideFocus() {
-      this.autoplay && this.pause('focused')
+      if (this.autoplay) {
+        this.pause('focused')
+      }
     },
     onSlideBlur() {
-      this.autoplay && this.autoplaying === 'focused' && this.autoPlay('blur')
+      if (this.autoplay && this.autoplaying === 'focused') {
+        this.runAutoPlay('blur')
+      }
     },
     selectHandler(options) {
       if (this.focusOnSelect) {


### PR DESCRIPTION
I figured out my carousel was sending a lot of `beforeChange` events even though nothing seemingly changed.

I found out **the condition to trigger the autoplay was wrong** and so it always triggers the autoplay timer whatever the props are.

To avoid any more confusion, I renamed the `autoPlay` method to `runAutoPlay`, so we're sure the names are more distincts than just a capital letter!