### PR TITLE
Make event names kebab case

### DIFF
--- a/src/InnerSlider.vue
+++ b/src/InnerSlider.vue
@@ -75,7 +75,7 @@ export default {
       let slidesToLoad = getOnDemandLazySlides(this.spec)
       if (slidesToLoad.length > 0) {
         this.lazyLoadedList = this.lazyLoadedList.concat(slidesToLoad)
-        this.$parent.$emit('lazyLoad', slidesToLoad)
+        this.$parent.$emit('lazy-load', slidesToLoad)
       }
     }
   },
@@ -120,7 +120,7 @@ export default {
   },
   updated() {
     this.checkImagesLoad()
-    this.$parent.$emit('reInit')
+    this.$parent.$emit('re-init')
     if (this.lazyLoad) {
       let slidesToLoad = getOnDemandLazySlides({
         ...this.$props,
@@ -128,7 +128,7 @@ export default {
       })
       if (slidesToLoad.length > 0) {
         this.lazyLoadedList = this.lazyLoadedList.concat(slidesToLoad)
-        this.$parent.$emit('lazyLoad', slidesToLoad)
+        this.$parent.$emit('lazy-load', slidesToLoad)
       }
     }
     this.adaptHeight()
@@ -278,12 +278,12 @@ export default {
         useCSS: this.useCSS && !dontAnimate,
       })
       if (!state) return
-      this.$parent.$emit('beforeChange', currentSlide, state.currentSlide)
+      this.$parent.$emit('before-change', currentSlide, state.currentSlide)
       let slidesToLoad = state.lazyLoadedList.filter(
         value => this.lazyLoadedList.indexOf(value) < 0,
       )
       if (slidesToLoad.length) {
-        this.$parent.$emit('lazyLoad', slidesToLoad)
+        this.$parent.$emit('lazy-load', slidesToLoad)
       }
       Object.assign(this.$data, state)
       if (asNavFor) {
@@ -298,7 +298,8 @@ export default {
             this.animating = animating
           }, 10),
         )
-        this.$parent.$emit('afterChange', state.currentSlide)
+        this.$parent.$emit('after-change', state.currentSlide)
+
         // delete this.animationEndCallback
         this.animationEndCallback = undefined
       }, speed)
@@ -362,7 +363,7 @@ export default {
             image.onload = handler
             image.onerror = () => {
               handler()
-              this.$parent.$emit('lazyLoadError')
+              this.$parent.$emit('lazy-load-error')
             }
           }
         }
@@ -393,7 +394,7 @@ export default {
       }
       if (slidesToLoad.length > 0) {
         this.lazyLoadedList = this.lazyLoadedList.concat(slidesToLoad)
-        this.$parent.$emit('lazyLoad', slidesToLoad)
+        this.$parent.$emit('lazy-load', slidesToLoad)
       } else {
         if (this.lazyLoadTimer) {
           clearInterval(this.lazyLoadTimer)
@@ -610,7 +611,7 @@ export default {
         <SliderDots
           {...{ props: dotProps }}
           {...{ nativeOn: dotNativeOn }}
-          onDotClicked={this.changeSlide}
+          onDot-clicked={this.changeSlide}
         />
       )
     }
@@ -622,13 +623,13 @@ export default {
       prevArrow = (
         <SliderArrow
           {...{ props: { ...arrowProps, type: 'previous' } }}
-          onArrowClicked={this.changeSlide}
+          onArrow-clicked={this.changeSlide}
         />
       )
       nextArrow = (
         <SliderArrow
           {...{ props: { ...arrowProps, type: 'next' } }}
-          onArrowClicked={this.changeSlide}
+          onArrow-clicked={this.changeSlide}
         />
       )
     }
@@ -691,7 +692,7 @@ export default {
             ref="track"
             {...{ props: trackProps }}
             {...{ nativeOn: trackNativeOn }}
-            onChildClicked={this.selectHandler}>
+            onChild-clicked={this.selectHandler}>
             {this.$slots.default}
           </SliderTrack>
         </div>

--- a/src/SliderArrow.vue
+++ b/src/SliderArrow.vue
@@ -52,7 +52,7 @@ export default {
     mergeVNodeData(arrow, 'on', {
       click: () => {
         if (clickable) {
-          this.$emit('arrowClicked', { message: this.type })
+          this.$emit('arrow-clicked', { message: this.type })
         }
       },
     })

--- a/src/SliderDots.vue
+++ b/src/SliderDots.vue
@@ -58,7 +58,7 @@ export default {
         <li
           key={i}
           class={className}
-          onClick={() => this.$emit('dotClicked', dotOptions)}>
+          onClick={() => this.$emit('dot-clicked', dotOptions)}>
           {customPaging}
         </li>
       )

--- a/src/SliderTrack.vue
+++ b/src/SliderTrack.vue
@@ -90,7 +90,7 @@ export default {
       mergeVNodeData(clone, 'on', {
         click: e => {
           getData(slide, 'on.click', () => {})(e)
-          this.$emit('childClicked', options.childOnClickOptions)
+          this.$emit('child-clicked', options.childOnClickOptions)
         },
       })
 


### PR DESCRIPTION
When using in-DOM-templates, it is impossible to listen to the custom events emitted by vue-slick-carousel. The reason is that listeners inside in-DOM templates are always transformed to lowercase, as explained here: https://vuejs.org/v2/guide/components-custom-events.html#Event-Names

This means we need to use *kebab-cased* event names in order to be able to listen to events in in-DOM templates.

This is a breaking change, so it might require a new major release.

refs #115 

I see that there is also an existing pull request at #142 which leaves out a few events that I've changed here as well (concerning arrows etc.)

The discussion started by @kyuwoo-choi in #142 still applies. 