### PR TITLE
Fix weird behaviour of carousel after goTo functionality

### DIFF
--- a/src/innerSliderUtils.js
+++ b/src/innerSliderUtils.js
@@ -133,6 +133,9 @@ export const changeSlide = (spec, options) => {
   } else if (options.message === 'next') {
     slideOffset = indexOffset === 0 ? slidesToScroll : indexOffset
     targetSlide = currentSlide + slideOffset
+    if( !infinite && !lazyLoad && ( (targetSlide + slidesToScroll) > slideCount) ){
+      targetSlide = slideCount - slidesToScroll;
+    }
     if (lazyLoad && !infinite) {
       targetSlide = ((currentSlide + slidesToScroll) % slideCount) + indexOffset
     }


### PR DESCRIPTION
After navigating to a slide using goTo() functionality, carousel navigation was breaking at the last few slides. There were 2 scenarios happened based on number of slides.
1) Carousel won't allow to navigate to few slides using next arrow even though the slides can be seen if we swipe to right.
2) Carousel will ended up with last few slides and some empty spots for the last few slides instead of adjusting the landing slide when there are no enough slides for the last set.