### PR TITLE
fix: makes slide clickable after swipe

### DIFF
--- a/src/InnerSlider.vue
+++ b/src/InnerSlider.vue
@@ -457,6 +457,9 @@ export default {
         slideIndex: this.currentSlide,
       })
       if (!state) return
+      if (!state['swiping']) {
+        this.clickable = true
+      }
       let triggerSlideHandler = state['triggerSlideHandler']
       // delete state["triggerSlideHandler"];
       this.triggerSlideHandler = undefined


### PR DESCRIPTION
Closes #167 

I've added checking `state['swiping']` just to be sure that it's not swiping anymore. Same check is in `swipeMove`. Maybe it is not needed, let mi know.