### PR TITLE
Fix missing type on button

### DIFF
--- a/src/SliderDots.vue
+++ b/src/SliderDots.vue
@@ -51,7 +51,7 @@ export default {
       const customPaging = this.customPaging ? (
         this.customPaging(i)[0]
       ) : (
-        <button>{i + 1}</button>
+        <button type="button">{i + 1}</button>
       )
 
       return (


### PR DESCRIPTION
Hi,

Dots in the slider are buttons but don't have type (by default in forms it's a submit).
Imo button type is more suitable.