### PR TITLE
Fix carousel slot rendering skipped inner scopedSlots

### DIFF
--- a/src/vNodeUtils.js
+++ b/src/vNodeUtils.js
@@ -33,7 +33,7 @@ const DATA_KEYS = [
   'on',
   'nativeOn',
   'directives',
-  'scopesSlots',
+  'scopedSlots',
   'slot',
   'ref',
   'key',


### PR DESCRIPTION
When rendering the carousel slot with a component, itself using a scopedSlot, it won't be rendered correctly. The scopedSlot is skipped and our component is rendered as if it didn't received any slot.

Example:
```html
<VueSlickCarousel>
  <CarouselCard>
    <h1>Here is my carousel card</h1>
    <template #footer="{ name }"> <!-- This won't be rendered -->
      Author: {{ name }}
    </template>
  </CarouselCard>
</VueSlickCarousel>
```

Here, the scoped slot `footer` is never rendered, as if we never passed it.

---------

I digged into the library to understand the problem and turns out it's a simple typo in the keys to copy when cloning the children `vnode`...

Note: I know this won't be merged as the library isn't maintained anymore. I published this fix on my own fork and I'm using this in production for probably ever.